### PR TITLE
kinematics_base: remove deprecated initialize function

### DIFF
--- a/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
+++ b/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h
@@ -346,24 +346,6 @@ public:
                          double search_discretization);
 
   /**
-   * @brief  Initialization function for the kinematics, for use with non-chain IK solvers
-   * @param robot_description This parameter can be used as an identifier for the robot kinematics is computed for;
-   * For example, rhe name of the ROS parameter that contains the robot description;
-   * @param group_name The group for which this solver is being configured
-   * @param base_frame The base frame in which all input poses are expected.
-   * This may (or may not) be the root frame of the chain that the solver operates on
-   * @param tip_frames A vector of tips of the kinematic tree
-   * @param search_discretization The discretization of the search when the solver steps through the redundancy
-   * @return True if initialization was successful, false otherwise
-   *
-   * Instead of this method, use the method passing in a RobotModel!
-   * Default implementation calls initialize() for tip_frames[0] and reports an error if tip_frames.size() != 1.
-   */
-  virtual bool initialize(const std::string& robot_description, const std::string& group_name,
-                          const std::string& base_frame, const std::vector<std::string>& tip_frames,
-                          double search_discretization);
-
-  /**
    * @brief  Initialization function for the kinematics, for use with kinematic chain IK solvers
    * @param robot_model - allow the URDF to be loaded much quicker by passing in a pre-parsed model of the robot
    * @param group_name The group for which this solver is being configured
@@ -373,7 +355,6 @@ public:
    * @param search_discretization The discretization of the search when the solver steps through the redundancy
    * @return true if initialization was successful, false otherwise
    *
-   * When returning false, the KinematicsPlugingLoader will use the old method, passing a robot_description.
    * Default implementation returns false and issues a warning to implement this new API.
    * TODO: Make this method purely virtual after some soaking time, replacing the fallback.
    */

--- a/moveit_core/kinematics_base/src/kinematics_base.cpp
+++ b/moveit_core/kinematics_base/src/kinematics_base.cpp
@@ -80,19 +80,14 @@ void KinematicsBase::setValues(const std::string& robot_description, const std::
   setSearchDiscretization(search_discretization);
 }
 
-bool KinematicsBase::initialize(const std::string& robot_description, const std::string& group_name,
-                                const std::string& base_frame, const std::vector<std::string>& tip_frames,
-                                double search_discretization)
-{
-  RCLCPP_ERROR(LOGGER, "IK plugin for group '%s' relies on deprecated API.", group_name.c_str());
-  return false;
-}
-
 bool KinematicsBase::initialize(const rclcpp::Node::SharedPtr& node, const moveit::core::RobotModel& robot_model,
                                 const std::string& group_name, const std::string& base_frame,
                                 const std::vector<std::string>& tip_frames, double search_discretization)
 {
-  RCLCPP_ERROR(LOGGER, "IK plugin for group '%s' relies on deprecated API.", group_name.c_str());
+  RCLCPP_ERROR(LOGGER,
+               "IK plugin for group '%s' relies on deprecated API. "
+               "Please implement initialize(RobotModel, ...).",
+               group_name.c_str());
   return false;
 }
 

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -33,6 +33,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
 pluginlib_export_plugin_description_file(moveit_core kdl_kinematics_plugin_description.xml)
 pluginlib_export_plugin_description_file(moveit_core lma_kinematics_plugin_description.xml)
 pluginlib_export_plugin_description_file(moveit_core srv_kinematics_plugin_description.xml)
+pluginlib_export_plugin_description_file(moveit_core cached_ik_kinematics_plugin_description.xml)
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS})
 
@@ -40,13 +41,14 @@ add_subdirectory(kdl_kinematics_plugin)
 add_subdirectory(lma_kinematics_plugin)
 add_subdirectory(srv_kinematics_plugin)
 # add_subdirectory(ikfast_kinematics_plugin)
-# add_subdirectory(cached_ik_kinematics_plugin)
+add_subdirectory(cached_ik_kinematics_plugin)
 add_subdirectory(test)
 
 ament_export_libraries(
     moveit_kdl_kinematics_plugin
     moveit_lma_kinematics_plugin
-    moveit_srv_kinematics_plugin)
+    moveit_srv_kinematics_plugin
+    moveit_cached_ik_kinematics_plugin)
 ament_export_include_directories(include)
 ament_export_dependencies(pluginlib)
 ament_export_dependencies(moveit_core)

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -4,36 +4,44 @@ find_package(ur_kinematics QUIET)
 find_package(Boost COMPONENTS filesystem program_options REQUIRED)
 
 set(MOVEIT_LIB_NAME moveit_cached_ik_kinematics_base)
-add_library(${MOVEIT_LIB_NAME} src/ik_cache.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/ik_cache.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(${MOVEIT_LIB_NAME}
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${catkin_LIBRARIES})
+    ${Boost_FILESYSTEM_LIBRARY})
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  rclcpp
+  moveit_core
+  moveit_msgs
+)
 install(TARGETS ${MOVEIT_LIB_NAME} 
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin)
 
 if(trac_ik_kinematics_plugin_FOUND)
     include_directories(${trac_ik_kinematics_plugin_INCLUDE_DIRS})
 endif(trac_ik_kinematics_plugin_FOUND)
 
 set(MOVEIT_LIB_NAME moveit_cached_ik_kinematics_plugin)
-add_library(${MOVEIT_LIB_NAME} src/cached_ik_kinematics_plugin.cpp)
+add_library(${MOVEIT_LIB_NAME} SHARED src/cached_ik_kinematics_plugin.cpp)
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+ament_target_dependencies(${MOVEIT_LIB_NAME}
+  rclcpp
+  moveit_core
+  moveit_msgs
+)
 target_link_libraries(${MOVEIT_LIB_NAME}
     moveit_cached_ik_kinematics_base
     moveit_kdl_kinematics_plugin
-    moveit_srv_kinematics_plugin
-    ${catkin_LIBRARIES})
+    moveit_srv_kinematics_plugin)
 if(trac_ik_kinematics_plugin_FOUND)
     target_link_libraries(${MOVEIT_LIB_NAME} ${trac_ik_kinematics_plugin_LIBRARIES})
     set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES COMPILE_DEFINITIONS "CACHED_IK_KINEMATICS_TRAC_IK")
 endif()
 install(TARGETS ${MOVEIT_LIB_NAME} 
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin)
 
 # This is just for testing purposes; the arms from Universal Robots have
 # analytic solvers, so caching just adds extra overhead.
@@ -41,19 +49,18 @@ if(ur_kinematics_FOUND)
     include_directories(${ur_kinematics_INCLUDE_DIRS})
     foreach(UR 3 5 10)
         set(MOVEIT_LIB_NAME moveit_cached_ur${UR}_kinematics_plugin)
-        add_library(${MOVEIT_LIB_NAME} src/cached_ur_kinematics_plugin.cpp)
+        add_library(${MOVEIT_LIB_NAME} SHARED src/cached_ur_kinematics_plugin.cpp)
         set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
         find_library(ur${UR}_pluginlib ur${UR}_moveit_plugin PATHS ${ur_kinematics_LIBRARY_DIRS})
         target_link_libraries(${MOVEIT_LIB_NAME}
             moveit_cached_ik_kinematics_base
-            ${ur${UR}_pluginlib}
-            ${catkin_LIBRARIES})
+            ${ur${UR}_pluginlib})
         install(TARGETS ${MOVEIT_LIB_NAME} 
-                LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-                ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-                RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+                LIBRARY DESTINATION lib
+                ARCHIVE DESTINATION lib
+                RUNTIME DESTINATION bin)
     endforeach()
 endif()
 
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
-install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin-inl.h
@@ -55,11 +55,12 @@ void CachedIKKinematicsPlugin<KinematicsPlugin>::initCache(const std::string& ro
 {
   IKCache::Options opts;
   int max_cache_size;  // rosparam can't handle unsigned int
-  kinematics::KinematicsBase::lookupParam("max_cache_size", max_cache_size, static_cast<int>(opts.max_cache_size));
+  kinematics::KinematicsBase::lookupParam(node_, "max_cache_size", max_cache_size,
+                                          static_cast<int>(opts.max_cache_size));
   opts.max_cache_size = max_cache_size;
-  kinematics::KinematicsBase::lookupParam("min_pose_distance", opts.min_pose_distance, 1.0);
-  kinematics::KinematicsBase::lookupParam("min_joint_config_distance", opts.min_joint_config_distance, 1.0);
-  kinematics::KinematicsBase::lookupParam<std::string>("cached_ik_path", opts.cached_ik_path, "");
+  kinematics::KinematicsBase::lookupParam(node_, "min_pose_distance", opts.min_pose_distance, 1.0);
+  kinematics::KinematicsBase::lookupParam(node_, "min_joint_config_distance", opts.min_joint_config_distance, 1.0);
+  kinematics::KinematicsBase::lookupParam<std::string>(node_, "cached_ik_path", opts.cached_ik_path, "");
 
   cache_.initializeCache(robot_id, group_name, cache_name, KinematicsPlugin::getJointNames().size(), opts);
 
@@ -70,14 +71,12 @@ void CachedIKKinematicsPlugin<KinematicsPlugin>::initCache(const std::string& ro
 }
 
 template <class KinematicsPlugin>
-bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::initialize(const moveit::core::RobotModel& robot_model,
-                                                                    const std::string& group_name,
-                                                                    const std::string& base_frame,
-                                                                    const std::vector<std::string>& tip_frames,
-                                                                    double search_discretization)
+bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::initialize(
+    const rclcpp::Node::SharedPtr& node, const moveit::core::RobotModel& robot_model, const std::string& group_name,
+    const std::string& base_frame, const std::vector<std::string>& tip_frames, double search_discretization)
 {
   // call initialize method of wrapped class
-  if (!KinematicsPlugin::initialize(robot_model, group_name, base_frame, tip_frames, search_discretization))
+  if (!KinematicsPlugin::initialize(node, robot_model, group_name, base_frame, tip_frames, search_discretization))
     return false;
 
   std::string cache_name = base_frame;
@@ -88,25 +87,7 @@ bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::initialize(const moveit
 }
 
 template <class KinematicsPlugin>
-bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::initialize(const std::string& robot_description,
-                                                                    const std::string& group_name,
-                                                                    const std::string& base_frame,
-                                                                    const std::vector<std::string>& tip_frames,
-                                                                    double search_discretization)
-{
-  // call initialize method of wrapped class
-  if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frames, search_discretization))
-    return false;
-
-  std::string cache_name = base_frame;
-  std::accumulate(tip_frames.begin(), tip_frames.end(), cache_name);
-  CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.initializeCache(robot_description, group_name, cache_name,
-                                                                     KinematicsPlugin::getJointNames().size());
-  return true;
-}
-
-template <class KinematicsPlugin>
-bool CachedIKKinematicsPlugin<KinematicsPlugin>::getPositionIK(const geometry_msgs::Pose& ik_pose,
+bool CachedIKKinematicsPlugin<KinematicsPlugin>::getPositionIK(const geometry_msgs::msg::Pose& ik_pose,
                                                                const std::vector<double>& ik_seed_state,
                                                                std::vector<double>& solution,
                                                                moveit_msgs::msg::MoveItErrorCodes& error_code,
@@ -122,7 +103,7 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::getPositionIK(const geometry_ms
 }
 
 template <class KinematicsPlugin>
-bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(const geometry_msgs::msg::Pose& ik_pose,
                                                                   const std::vector<double>& ik_seed_state,
                                                                   double timeout, std::vector<double>& solution,
                                                                   moveit_msgs::msg::MoveItErrorCodes& error_code,
@@ -146,7 +127,7 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(const geometry
 
 template <class KinematicsPlugin>
 bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
-    const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+    const geometry_msgs::msg::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
     const std::vector<double>& consistency_limits, std::vector<double>& solution,
     moveit_msgs::msg::MoveItErrorCodes& error_code, const KinematicsQueryOptions& options) const
 {
@@ -167,7 +148,7 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
 }
 
 template <class KinematicsPlugin>
-bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(const geometry_msgs::msg::Pose& ik_pose,
                                                                   const std::vector<double>& ik_seed_state,
                                                                   double timeout, std::vector<double>& solution,
                                                                   const IKCallbackFn& solution_callback,
@@ -192,7 +173,7 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(const geometry
 
 template <class KinematicsPlugin>
 bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
-    const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+    const geometry_msgs::msg::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
     const std::vector<double>& consistency_limits, std::vector<double>& solution, const IKCallbackFn& solution_callback,
     moveit_msgs::msg::MoveItErrorCodes& error_code, const KinematicsQueryOptions& options) const
 {
@@ -214,7 +195,7 @@ bool CachedIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
 
 template <class KinematicsPlugin>
 bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
-    const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state, double timeout,
+    const std::vector<geometry_msgs::msg::Pose>& ik_poses, const std::vector<double>& ik_seed_state, double timeout,
     const std::vector<double>& consistency_limits, std::vector<double>& solution, const IKCallbackFn& solution_callback,
     moveit_msgs::msg::MoveItErrorCodes& error_code, const KinematicsQueryOptions& options,
     const moveit::core::RobotState* context_state) const
@@ -239,4 +220,4 @@ bool CachedMultiTipIKKinematicsPlugin<KinematicsPlugin>::searchPositionIK(
     CachedIKKinematicsPlugin<KinematicsPlugin>::cache_.updateCache(nearest, poses, solution);
   return solution_found;
 }
-}
+}  // namespace cached_ik_kinematics_plugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
@@ -36,19 +36,22 @@
 
 #pragma once
 
-#include <moveit/kinematics_base/kinematics_base.h>
-#include <moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h>
-#include <moveit/robot_model/robot_model.h>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Quaternion.h>
 #include <moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h>
+#include <moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h>
+#include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/robot_model/robot_model.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Vector3.h>
 #include <boost/filesystem.hpp>
-#include <unordered_map>
 #include <mutex>
+#include <unordered_map>
 #include <utility>
 
 namespace cached_ik_kinematics_plugin
 {
+static const rclcpp::Logger LOGGER =
+    rclcpp::get_logger("moveit_cached_ik_kinematics_plugin.cached_ik_kinematics_plugin");
+
 /** \brief A cache of inverse kinematic solutions */
 class IKCache
 {
@@ -68,13 +71,13 @@ public:
     \brief class to represent end effector pose
 
      tf2::Transform stores orientation as a matrix, so we define our
-     own pose class that maps more directly to geometry_msgs::Pose and
+     own pose class that maps more directly to geometry_msgs::msg::Pose and
      for which we can more easily define a distance metric.
   */
   struct Pose
   {
     Pose() = default;
-    Pose(const geometry_msgs::Pose& pose);
+    Pose(const geometry_msgs::msg::Pose& pose);
     tf2::Vector3 position;
     tf2::Quaternion orientation;
     /** compute the distance between this pose and another pose */
@@ -186,6 +189,7 @@ struct hasRobotModelAPI : std::false_type
 
 template <typename KinematicsPlugin>
 struct hasRobotModelAPI<KinematicsPlugin, decltype(std::declval<KinematicsPlugin&>().initialize(
+                                              std::declval<const rclcpp::Node::SharedPtr&>(),
                                               std::declval<const moveit::core::RobotModel&>(), std::string(),
                                               std::string(), std::vector<std::string>(), 0.0))> : std::true_type
 {
@@ -220,43 +224,40 @@ public:
 
   // virtual methods that need to be wrapped:
 
-  bool initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
-                  const std::string& base_frame, const std::vector<std::string>& tip_frames,
-                  double search_discretization) override
+  bool initialize(const rclcpp::Node::SharedPtr& node, const moveit::core::RobotModel& robot_model,
+                  const std::string& group_name, const std::string& base_frame,
+                  const std::vector<std::string>& tip_frames, double search_discretization) override
   {
-    return initializeImpl(robot_model, group_name, base_frame, tip_frames, search_discretization);
+    node_ = node;
+    return initializeImpl(node, robot_model, group_name, base_frame, tip_frames, search_discretization);
   }
 
-  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_frame,
-                  const std::string& tip_frame, double search_discretization) override
-  {
-    return initializeImpl(robot_description, group_name, base_frame, tip_frame, search_discretization);
-  }
-
-  bool getPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+  bool getPositionIK(const geometry_msgs::msg::Pose& ik_pose, const std::vector<double>& ik_seed_state,
                      std::vector<double>& solution, moveit_msgs::msg::MoveItErrorCodes& error_code,
                      const KinematicsQueryOptions& options = KinematicsQueryOptions()) const override;
 
-  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
-                        std::vector<double>& solution, moveit_msgs::msg::MoveItErrorCodes& error_code,
+  bool searchPositionIK(const geometry_msgs::msg::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+                        double timeout, std::vector<double>& solution, moveit_msgs::msg::MoveItErrorCodes& error_code,
                         const KinematicsQueryOptions& options = KinematicsQueryOptions()) const override;
 
-  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
-                        const std::vector<double>& consistency_limits, std::vector<double>& solution,
+  bool searchPositionIK(const geometry_msgs::msg::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+                        double timeout, const std::vector<double>& consistency_limits, std::vector<double>& solution,
                         moveit_msgs::msg::MoveItErrorCodes& error_code,
                         const KinematicsQueryOptions& options = KinematicsQueryOptions()) const override;
 
-  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
-                        std::vector<double>& solution, const IKCallbackFn& solution_callback,
+  bool searchPositionIK(const geometry_msgs::msg::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+                        double timeout, std::vector<double>& solution, const IKCallbackFn& solution_callback,
                         moveit_msgs::msg::MoveItErrorCodes& error_code,
                         const KinematicsQueryOptions& options = KinematicsQueryOptions()) const override;
 
-  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
-                        const std::vector<double>& consistency_limits, std::vector<double>& solution,
+  bool searchPositionIK(const geometry_msgs::msg::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+                        double timeout, const std::vector<double>& consistency_limits, std::vector<double>& solution,
                         const IKCallbackFn& solution_callback, moveit_msgs::msg::MoveItErrorCodes& error_code,
                         const KinematicsQueryOptions& options = KinematicsQueryOptions()) const override;
 
 private:
+  rclcpp::Node::SharedPtr node_;
+
   IKCache cache_;
 
   void initCache(const std::string& robot_id, const std::string& group_name, const std::string& cache_name);
@@ -266,18 +267,18 @@ private:
      However, as templates and virtual functions cannot be combined, we need helpers initializeImpl(). */
   template <class T = KinematicsPlugin>
   typename std::enable_if<hasRobotModelAPI<T>::value, bool>::type
-  initializeImpl(const moveit::core::RobotModel& robot_model, const std::string& group_name,
-                 const std::string& base_frame, const std::vector<std::string>& tip_frames,
-                 double search_discretization)
+  initializeImpl(const rclcpp::Node::SharedPtr& node, const moveit::core::RobotModel& robot_model,
+                 const std::string& group_name, const std::string& base_frame,
+                 const std::vector<std::string>& tip_frames, double search_discretization)
   {
     if (tip_frames.size() != 1)
     {
-      ROS_ERROR_NAMED("cached_ik", "This solver does not support multiple tip frames");
+      RCLCPP_ERROR(LOGGER, "This solver does not support multiple tip frames");
       return false;
     }
 
     // call initialize method of wrapped class
-    if (!KinematicsPlugin::initialize(robot_model, group_name, base_frame, tip_frames, search_discretization))
+    if (!KinematicsPlugin::initialize(node, robot_model, group_name, base_frame, tip_frames, search_discretization))
       return false;
     initCache(robot_model.getName(), group_name, base_frame + tip_frames[0]);
     return true;
@@ -285,27 +286,8 @@ private:
 
   template <class T = KinematicsPlugin>
   typename std::enable_if<!hasRobotModelAPI<T>::value, bool>::type
-  initializeImpl(const moveit::core::RobotModel&, const std::string&, const std::string&,
-                 const std::vector<std::string>&, double)
-  {
-    return false;  // API not supported
-  }
-
-  template <class T = KinematicsPlugin>
-  typename std::enable_if<hasRobotDescAPI<T>::value, bool>::type
-  initializeImpl(const std::string& robot_description, const std::string& group_name, const std::string& base_frame,
-                 const std::string& tip_frame, double search_discretization)
-  {
-    // call initialize method of wrapped class
-    if (!KinematicsPlugin::initialize(robot_description, group_name, base_frame, tip_frame, search_discretization))
-      return false;
-    initCache(robot_description, group_name, base_frame + tip_frame);
-    return true;
-  }
-
-  template <class T = KinematicsPlugin>
-  typename std::enable_if<!hasRobotDescAPI<T>::value, bool>::type
-  initializeImpl(const std::string&, const std::string&, const std::string&, const std::string&, double)
+  initializeImpl(const rclcpp::Node::SharedPtr& node, const moveit::core::RobotModel&, const std::string&,
+                 const std::string&, const std::vector<std::string>&, double)
   {
     return false;  // API not supported
   }
@@ -331,19 +313,16 @@ public:
   using IKCallbackFn = kinematics::KinematicsBase::IKCallbackFn;
   using KinematicsQueryOptions = kinematics::KinematicsQueryOptions;
 
-  bool initialize(const moveit::core::RobotModel& robot_model, const std::string& group_name,
-                  const std::string& base_frame, const std::vector<std::string>& tip_frames,
-                  double search_discretization) override;
-
-  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_frame,
+  bool initialize(const rclcpp::Node::SharedPtr& node, const moveit::core::RobotModel& robot_model,
+                  const std::string& group_name, const std::string& base_frame,
                   const std::vector<std::string>& tip_frames, double search_discretization) override;
 
-  bool searchPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
+  bool searchPositionIK(const std::vector<geometry_msgs::msg::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
                         double timeout, const std::vector<double>& consistency_limits, std::vector<double>& solution,
                         const IKCallbackFn& solution_callback, moveit_msgs::msg::MoveItErrorCodes& error_code,
                         const KinematicsQueryOptions& options = KinematicsQueryOptions(),
                         const moveit::core::RobotState* context_state = nullptr) const override;
 };
-}
+}  // namespace cached_ik_kinematics_plugin
 
 #include "cached_ik_kinematics_plugin-inl.h"

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/cached_ik_kinematics_plugin.h
@@ -286,7 +286,7 @@ private:
 
   template <class T = KinematicsPlugin>
   typename std::enable_if<!hasRobotModelAPI<T>::value, bool>::type
-  initializeImpl(const rclcpp::Node::SharedPtr& node, const moveit::core::RobotModel&, const std::string&,
+  initializeImpl(const rclcpp::Node::SharedPtr&, const moveit::core::RobotModel&, const std::string&,
                  const std::string&, const std::vector<std::string>&, double)
   {
     return false;  // API not supported

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/GreedyKCenters.h
@@ -38,9 +38,9 @@
 
 #pragma once
 
+#include <boost/numeric/ublas/matrix.hpp>
 #include <functional>
 #include <random>
-#include <boost/numeric/ublas/matrix.hpp>
 
 namespace cached_ik_kinematics_plugin
 {
@@ -127,4 +127,4 @@ protected:
   /** Random number generator used to select first center */
   std::mt19937 generator_{ std::random_device{}() };
 };
-}
+}  // namespace cached_ik_kinematics_plugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighbors.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighbors.h
@@ -38,8 +38,8 @@
 
 #pragma once
 
-#include <vector>
 #include <functional>
+#include <vector>
 
 namespace cached_ik_kinematics_plugin
 {
@@ -114,4 +114,4 @@ protected:
   /** \brief The used distance function */
   DistanceFunction distFun_;
 };
-}
+}  // namespace cached_ik_kinematics_plugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
@@ -38,13 +38,13 @@
 
 #pragma once
 
-#include "NearestNeighbors.h"
-#include "GreedyKCenters.h"
 #include <moveit/exceptions/exceptions.h>
-#include <unordered_set>
-#include <queue>
 #include <algorithm>
+#include <queue>
+#include <unordered_set>
 #include <utility>
+#include "GreedyKCenters.h"
+#include "NearestNeighbors.h"
 
 namespace cached_ik_kinematics_plugin
 {
@@ -718,4 +718,4 @@ protected:
   // \brief Cache of removed elements.
   std::unordered_set<const _T*> removed_;
 };
-}
+}  // namespace cached_ik_kinematics_plugin

--- a/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/src/ik_cache.cpp
@@ -95,8 +95,8 @@ void IKCache::initializeCache(const std::string& robot_id, const std::string& gr
     unsigned int num_tips;
     cache_file.read((char*)&num_tips, sizeof(unsigned int));
 
-    ROS_INFO_NAMED("cached_ik", "Found %d IK solutions for a %d-dof system with %d end effectors in %s",
-                   last_saved_cache_size_, num_dofs, num_tips, cache_file_name_.string().c_str());
+    RCLCPP_INFO(LOGGER, "Found %d IK solutions for a %d-dof system with %d end effectors in %s", last_saved_cache_size_,
+                num_dofs, num_tips, cache_file_name_.string().c_str());
 
     unsigned int position_size = 3 * sizeof(tf2Scalar);
     unsigned int orientation_size = 4 * sizeof(tf2Scalar);
@@ -123,9 +123,9 @@ void IKCache::initializeCache(const std::string& robot_id, const std::string& gr
       memcpy(&entry.second[0], buffer + offset_conf, config_size);
       ik_cache_.push_back(entry);
     }
-    ROS_INFO_NAMED("cached_ik", "freeing buffer");
+    RCLCPP_INFO(LOGGER, "freeing buffer");
     delete[] buffer;
-    ROS_INFO_NAMED("cached_ik", "freed buffer");
+    RCLCPP_INFO(LOGGER, "freed buffer");
     std::vector<IKEntry*> ik_entry_ptrs(last_saved_cache_size_);
     for (unsigned int i = 0; i < last_saved_cache_size_; ++i)
       ik_entry_ptrs[i] = &ik_cache_[i];
@@ -134,7 +134,7 @@ void IKCache::initializeCache(const std::string& robot_id, const std::string& gr
 
   num_joints_ = num_joints;
 
-  ROS_INFO_NAMED("cached_ik", "cache file %s initialized!", cache_file_name_.string().c_str());
+  RCLCPP_INFO(LOGGER, "cache file %s initialized!", cache_file_name_.string().c_str());
 }
 
 double IKCache::configDistance2(const std::vector<double>& config1, const std::vector<double>& config2) const
@@ -216,9 +216,9 @@ void IKCache::updateCache(const IKEntry& nearest, const std::vector<Pose>& poses
 void IKCache::saveCache() const
 {
   if (cache_file_name_.empty())
-    ROS_ERROR_NAMED("cached_ik", "can't save cache before initialization");
+    RCLCPP_ERROR(LOGGER, "can't save cache before initialization");
 
-  ROS_INFO_NAMED("cached_ik", "writing %ld IK solutions to %s", ik_cache_.size(), cache_file_name_.string().c_str());
+  RCLCPP_INFO(LOGGER, "writing %ld IK solutions to %s", ik_cache_.size(), cache_file_name_.string().c_str());
 
   boost::filesystem::ofstream cache_file(cache_file_name_, std::ios_base::binary | std::ios_base::out);
   unsigned int position_size = 3 * sizeof(tf2Scalar);
@@ -252,7 +252,7 @@ void IKCache::saveCache() const
 void IKCache::verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin& fk) const
 {
   const std::vector<std::string>& tip_names(fk.getTipFrames());
-  std::vector<geometry_msgs::Pose> poses(tip_names.size());
+  std::vector<geometry_msgs::msg::Pose> poses(tip_names.size());
   double error, max_error = 0.;
 
   for (const auto& entry : ik_cache_)
@@ -266,12 +266,12 @@ void IKCache::verifyCache(kdl_kinematics_plugin::KDLKinematicsPlugin& fk) const
     if (error > max_error)
       max_error = error;
     if (error > 1e-4)
-      ROS_ERROR_NAMED("cached_ik", "Cache entry is invalid, error = %g", error);
+      RCLCPP_ERROR(LOGGER, "Cache entry is invalid, error = %g", error);
   }
-  ROS_INFO_NAMED("cached_ik", "Max. error in cache entries is %g", max_error);
+  RCLCPP_INFO(LOGGER, "Max. error in cache entries is %g", max_error);
 }
 
-IKCache::Pose::Pose(const geometry_msgs::Pose& pose)
+IKCache::Pose::Pose(const geometry_msgs::msg::Pose& pose)
 {
   position.setX(pose.position.x);
   position.setY(pose.position.y);

--- a/moveit_kinematics/cached_ik_kinematics_plugin_description.xml
+++ b/moveit_kinematics/cached_ik_kinematics_plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="lib/libmoveit_cached_ik_kinematics_plugin">
+<library path="moveit_cached_ik_kinematics_plugin">
   <class name="cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin" type="cached_ik_kinematics_plugin::CachedIKKinematicsPlugin<kdl_kinematics_plugin::KDLKinematicsPlugin>" base_class_type="kinematics::KinematicsBase">
     <description>
       A kinematics plugin for persistently caching IK solutions computed with the KDL kinematics plugin.

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -211,8 +211,6 @@ protected:
 
     // initializing plugin
     ASSERT_TRUE(kinematics_solver_->initialize(node_, *robot_model_, group_name_, root_link_, { tip_link_ },
-                                               DEFAULT_SEARCH_DISCRETIZATION) ||
-                kinematics_solver_->initialize(ROBOT_DESCRIPTION_PARAM, group_name_, root_link_, { tip_link_ },
                                                DEFAULT_SEARCH_DISCRETIZATION))
         << "Solver failed to initialize";
 

--- a/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/moveit_ros/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -176,9 +176,6 @@ public:
           double search_res = search_res_.find(jmg->getName())->second[i];  // we know this exists, by construction
 
           if (!result->initialize(node_, jmg->getParentModel(), jmg->getName(),
-                                  (base.empty() || base[0] != '/') ? base : base.substr(1), tips, search_res) &&
-              // on failure: fallback to old method (TODO: remove in future)
-              !result->initialize(robot_description_, jmg->getName(),
                                   (base.empty() || base[0] != '/') ? base : base.substr(1), tips, search_res))
           {
             RCLCPP_ERROR(LOGGER, "Kinematics solver of type '%s' could not be initialized for group '%s'",


### PR DESCRIPTION
### Description

I was able to compile successfully with some fixes to the initialization with robot_description but since it's deprecated and the other overload is already removed I thought it's better to remove this function than push the fixes

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
